### PR TITLE
chore: fix env vars using react-script friendly dotenv file configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+REACT_APP_API_KEY={api_key}
+REACT_APP_AUTH_DOMAIN={auth_domain}
+REACT_APP_DATABASE_URL={db_url}
+REACT_APP_PROJECT_ID={project_id}
+REACT_APP_STORAGE_BUCKET={storage_bucket}
+REACT_APP_MESSAGING_SENDER_ID={messaging_sender_id}
+REACT_APP_APP_ID={app_id}
+REACT_APP_MEASUREMENT_ID={measurement_id}
+
+GENERATE_SOURCEMAP=false

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,8 @@
+REACT_APP_API_KEY={api_key}
+REACT_APP_AUTH_DOMAIN={auth_domain}
+REACT_APP_DATABASE_URL={db_url}
+REACT_APP_PROJECT_ID={project_id}
+REACT_APP_STORAGE_BUCKET={storage_bucket}
+REACT_APP_MESSAGING_SENDER_ID={messaging_sender_id}
+REACT_APP_APP_ID={app_id}
+REACT_APP_MEASUREMENT_ID={measurement_id}

--- a/.env.production
+++ b/.env.production
@@ -1,8 +1,0 @@
-REACT_APP_API_KEY={api_key}
-REACT_APP_AUTH_DOMAIN={auth_domain}
-REACT_APP_DATABASE_URL={db_url}
-REACT_APP_PROJECT_ID={project_id}
-REACT_APP_STORAGE_BUCKET={storage_bucket}
-REACT_APP_MESSAGING_SENDER_ID={messaging_sender_id}
-REACT_APP_APP_ID={app_id}
-REACT_APP_MEASUREMENT_ID={measurement_id}

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-/src/config/firebase-config.ts
+

--- a/src/config/firebase-config.ts
+++ b/src/config/firebase-config.ts
@@ -1,0 +1,12 @@
+export const config = {
+  firebaseConfig: {
+    apiKey: process.env.REACT_APP_API_KEY,
+    authDomain: process.env.REACT_APP_AUTH_DOMAIN,
+    databaseURL: process.env.REACT_APP_DATABASE_URL,
+    projectId: process.env.REACT_APP_PROJECT_ID,
+    storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
+    messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+    appId: process.env.REACT_APP_APP_ID,
+    measurementId: process.env.REACT_APP_MEASUREMENT_ID
+  },
+};


### PR DESCRIPTION
Hi!

This implementation is based on this: https://create-react-app.dev/docs/adding-custom-environment-variables/

Essentially, the environment variables are embedded during the build time and `react-scripts` is clever enough to determine which files to load.

For developers, what you must do is create a file called by running `touch env.local env.production.local` in the base directory of the project. This will create two files locally. Populate both files with variables that we'll keep off github, ask a developer for them.

The `.env.example` file is there to demonstrate which keys we currently use.


React scripts is clever and will load files in a special order, see below. Files on the left have more priority than files on the right:

**npm start:** `.env.development.local`, `.env.local`, `.env.development`, `.env`
**npm run build:** `.env.production.local`, `.env.local`, `.env.production`, `.env`
**npm test:** `.env.test.local`, `.env.test`, `.env` (note .env.local is missing)

These variables will act as the defaults if the machine does not explicitly set them.

So in our case, `env.local` will be used locally when you run `npm start` and `.env.production.local` will be used when we `npm run build` and `firebase deploy`.