### PR TITLE
Rot 322 byp accessibility

### DIFF
--- a/src/components/games/BuildYourPlate/BuildYourPlateGameScreen.tsx
+++ b/src/components/games/BuildYourPlate/BuildYourPlateGameScreen.tsx
@@ -166,8 +166,8 @@ const BuildYourPlateGameScreen = () => {
                 {getBYPTableHeaders &&
                   getBYPTableHeaders.map((URL, index) => (
                     <tr key={URL}>
-                      <div className="py:[1px] md:py-1 pr-3 bg-white z-10 relative border-r border-titansDarkBlue border-spacing-4">
-                        <th>
+                      <div className="py-0 md:py-1 pr-3 bg-white z-10 relative border-r border-titansDarkBlue">
+                        <th className="p-0">
                           <button
                             type="button"
                             onClick={() => {
@@ -186,13 +186,14 @@ const BuildYourPlateGameScreen = () => {
                           </button>
                         </th>
                       </div>
+                      <td className="bg-white z-10 relative pr-3" />
                       {getBYPTableData[index].items.map((cell) => (
                         <td
                           key={cell.name}
                           className={
                             getTableDataVisibility[index]
-                              ? "slide-in-row visible md:py-1 pl-3"
-                              : "invisible"
+                              ? "slide-in-row visible py-0 md:py-1"
+                              : "invisible py-0"
                           }
                         >
                           <button

--- a/src/components/games/BuildYourPlate/BuildYourPlateGameScreen.tsx
+++ b/src/components/games/BuildYourPlate/BuildYourPlateGameScreen.tsx
@@ -1,7 +1,3 @@
-// accessibility issues on BYP to be resolved
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useEffect, useState } from "react";
 import FirebaseAPI from "../../../api/FirebaseAPI";
 import { BYPItem, BYPTableRowFamily } from "../../../models/BYP/BYP";
@@ -117,20 +113,17 @@ const BuildYourPlateGameScreen = () => {
   const constructHeaders = (URLs: string[]) =>
     URLs.map((URL, index) => (
       <tr key={URL}>
-        <th
-          className="p:[1px] md:p-1"
-          onClick={() => {
-            setTableDataVisibility((newTableDataVisibility) =>
-              newTableDataVisibility.map((item, idx) => (idx === index ? !item : item))
-            );
-          }}
-          onKeyPress={() => {
-            setTableDataVisibility((newTableDataVisibility) =>
-              newTableDataVisibility.map((item, idx) => (idx === index ? !item : item))
-            );
-          }}
-        >
-          <img src={URL} alt={newBYPTableData[index].family} className={imageSize} />
+        <th className="p:[1px] md:p-1">
+          <button
+            type="button"
+            onClick={() => {
+              setTableDataVisibility((newTableDataVisibility) =>
+                newTableDataVisibility.map((item, idx) => (idx === index ? !item : item))
+              );
+            }}
+          >
+            <img src={URL} alt={newBYPTableData[index].family} className={imageSize} />
+          </button>
         </th>
       </tr>
     ));
@@ -141,14 +134,15 @@ const BuildYourPlateGameScreen = () => {
         key={item.family}
       >
         {item.items.map((cell) => (
-          <td
-            className="md:p-1"
-            key={cell.name}
-            onClick={() => {
-              toggleItemToPlate(cell);
-            }}
-          >
-            {cell.icon}
+          <td className="md:p-1" key={cell.name}>
+            <button
+              type="button"
+              onClick={() => {
+                toggleItemToPlate(cell);
+              }}
+            >
+              {cell.icon}
+            </button>
           </td>
         ))}
       </tr>
@@ -209,7 +203,7 @@ const BuildYourPlateGameScreen = () => {
           <div className="flex flex-wrap 1.5xl:flex-nowrap w-full">
             <table className="flex">
               <thead className="mr-3">{getBYPTableHeaders}</thead>
-              <thead className="w-[1px] h-full bg-titansDarkBlue" />
+              <div className="w-[1px] h-full bg-titansDarkBlue" />
               <tbody className="ml-3 overflow-x-hidden">
                 {!getLoading && getBYPTableData && constructRows(getBYPTableData)}
               </tbody>
@@ -220,15 +214,16 @@ const BuildYourPlateGameScreen = () => {
                 <img src={getPlateImage} alt="plate" />
                 <div>
                   {getBYPPlateData.map((plateItem, index) => (
-                    <div
+                    <button
                       className={`absolute ${PlateItemPositions[index]}`}
+                      type="button"
                       onClick={() => {
                         removeFromPlate([plateItem]);
                       }}
                       key={plateItem.key}
                     >
                       {plateItem.icon}
-                    </div>
+                    </button>
                   ))}
                 </div>
               </div>

--- a/src/components/games/BuildYourPlate/BuildYourPlateGameScreen.tsx
+++ b/src/components/games/BuildYourPlate/BuildYourPlateGameScreen.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from "react";
 import FirebaseAPI from "../../../api/FirebaseAPI";
-import { BYPItem, BYPTableRowFamily } from "../../../models/BYP/BYP";
 import TableHeaderImagesLinks, {
   imageSize,
   PlateItemPositions,
 } from "../../../data/BYPData/BYPData";
-import BuildYourPlateProcessor from "./BuildYourPlateProcessor";
+import useWindowDimensions from "../../../functions/ScreenWidth";
+import { BYPItem, BYPTableRowFamily } from "../../../models/BYP/BYP";
 import { useGameStartedContext } from "../GameContext";
 import GameModalScreen from "../GameModalScreen";
-import useWindowDimensions from "../../../functions/ScreenWidth";
-import BuildYourPlatePlatePreviewScreen from "./BuildYourPlatePlatePreviewScreen";
 import BuildYourPlateIcon from "./BuildYourPlateIcon";
+import BuildYourPlatePlatePreviewScreen from "./BuildYourPlatePlatePreviewScreen";
+import BuildYourPlateProcessor from "./BuildYourPlateProcessor";
 
 let newBYPTableData: BYPTableRowFamily[] = [
   { family: "Meat", items: [] },
@@ -35,11 +35,10 @@ const BuildYourPlateGameScreen = () => {
   const [getTableDataVisibility, setTableDataVisibility] = useState<boolean[]>(
     Array(7).fill(false)
   );
-  const [getBYPTableHeaders, setBYPTableHeaders] = useState<React.ReactNode>();
+  const [getBYPTableHeaders, setBYPTableHeaders] = useState<string[]>();
   const [getPlateImage, setPlateImage] = useState<string>();
   const [getTickImage, setTickImage] = useState<React.ReactNode>();
   const [getButtonColor, setButtonColor] = useState<string>();
-  const [getLoading, setLoading] = useState<boolean>(true);
 
   const { width } = useWindowDimensions();
 
@@ -110,44 +109,6 @@ const BuildYourPlateGameScreen = () => {
     });
   };
 
-  const constructHeaders = (URLs: string[]) =>
-    URLs.map((URL, index) => (
-      <tr key={URL}>
-        <th className="p:[1px] md:p-1">
-          <button
-            type="button"
-            onClick={() => {
-              setTableDataVisibility((newTableDataVisibility) =>
-                newTableDataVisibility.map((item, idx) => (idx === index ? !item : item))
-              );
-            }}
-          >
-            <img src={URL} alt={newBYPTableData[index].family} className={imageSize} />
-          </button>
-        </th>
-      </tr>
-    ));
-  const constructRows = (BYPTableData: BYPTableRowFamily[]) =>
-    BYPTableData.map((item, index) => (
-      <tr
-        className={getTableDataVisibility[index] ? "slide-in-row visible" : "invisible"}
-        key={item.family}
-      >
-        {item.items.map((cell) => (
-          <td className="md:p-1" key={cell.name}>
-            <button
-              type="button"
-              onClick={() => {
-                toggleItemToPlate(cell);
-              }}
-            >
-              {cell.icon}
-            </button>
-          </td>
-        ))}
-      </tr>
-    ));
-
   useEffect(() => {
     BuildYourPlateProcessor.fetchAllUrls().then(async (res) => {
       if (!res) return;
@@ -160,13 +121,12 @@ const BuildYourPlateGameScreen = () => {
           selected: false,
           score: item.score,
         }));
-        setBYPTableHeaders(constructHeaders(headers));
+        setBYPTableHeaders(headers);
         setBYPTableData(BuildYourPlateProcessor.processRows(BYPItems));
         FirebaseAPI.fetchImages("Games/BigPlate.png").then((BPres) => setPlateImage(BPres));
         FirebaseAPI.fetchImages("Games/tick.png").then((Tickres) => {
           setTickImage(<img src={Tickres} alt="Tick" />);
         });
-        setLoading(false);
       });
     });
   }, []);
@@ -202,10 +162,51 @@ const BuildYourPlateGameScreen = () => {
           <p className="font-bold text-[22px] pb-4 text-titansDarkBlue">Food Families</p>
           <div className="flex flex-wrap 1.5xl:flex-nowrap w-full">
             <table className="flex">
-              <thead className="mr-3">{getBYPTableHeaders}</thead>
-              <div className="w-[1px] h-full bg-titansDarkBlue" />
-              <tbody className="ml-3 overflow-x-hidden">
-                {!getLoading && getBYPTableData && constructRows(getBYPTableData)}
+              <tbody className="overflow-x-hidden">
+                {getBYPTableHeaders &&
+                  getBYPTableHeaders.map((URL, index) => (
+                    <tr key={URL}>
+                      <div className="py:[1px] md:py-1 pr-3 bg-white z-10 relative border-r border-titansDarkBlue border-spacing-4">
+                        <th>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setTableDataVisibility((newTableDataVisibility) =>
+                                newTableDataVisibility.map((item, idx) =>
+                                  idx === index ? !item : item
+                                )
+                              );
+                            }}
+                          >
+                            <img
+                              src={URL}
+                              alt={newBYPTableData[index].family}
+                              className={imageSize}
+                            />
+                          </button>
+                        </th>
+                      </div>
+                      {getBYPTableData[index].items.map((cell) => (
+                        <td
+                          key={cell.name}
+                          className={
+                            getTableDataVisibility[index]
+                              ? "slide-in-row visible md:py-1 pl-3"
+                              : "invisible"
+                          }
+                        >
+                          <button
+                            type="button"
+                            onClick={() => {
+                              toggleItemToPlate(cell);
+                            }}
+                          >
+                            {cell.icon}
+                          </button>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
               </tbody>
             </table>
 


### PR DESCRIPTION
- Replaced clickable divs with buttons, so tabindex and onkeypress are automatically set
- Rearranged the order of the elements so the rows appear directly after their heading in the dom, meaning that they are focussed on in that order when using tab