### PR TITLE
Rot 344: Navigation / breadcrumb issues

### DIFF
--- a/cypress/e2e/food-nutrition.cy.ts
+++ b/cypress/e2e/food-nutrition.cy.ts
@@ -7,13 +7,13 @@ describe("Food & Nutrition", () => {
   });
 
   it("check a11y category page", () => {
-    cy.visit("http://localhost:3000/NutritionalInformation");
+    cy.visit("http://localhost:3000/FoodAndNutrition");
     cy.injectAxe();
     cy.checkA11y(null, null, terminalLog, true);
   });
 
   it("check a11y food page", () => {
-    cy.visit("http://localhost:3000/NutritionalInformation/Fish/Salmon");
+    cy.visit("http://localhost:3000/FoodAndNutrition/Fish/Salmon");
     cy.injectAxe();
     cy.checkA11y(null, null, terminalLog, true);
   });
@@ -21,7 +21,7 @@ describe("Food & Nutrition", () => {
   it("Can view fried chicken information ", () => {
     // TODO: update this test for non-mobile views
     cy.findByRole("button", { name: /menu-toggle/i }).click();
-    cy.get('[data-testid="mobile-menu"] [href="/NutritionalInformation"]').click();
+    cy.get('[data-testid="mobile-menu"] [href="/FoodAndNutrition"]').click();
     cy.get('[data-testid="Fast Food"]').click();
     cy.get('[data-testid="Fried Chicken"]').click();
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -23,37 +23,37 @@ const App: React.FC = () => (
   <div className="layout-container">
     <Navbar />
     <main>
-    <Routes>
-      <Route path="/"/>
-      <Route index element={<HomePageComponents />} />
-      <Route path="NutritionalInformation">
-        <Route index element={<NutritionalInformation showFood/>} />
+      <Routes>
+        <Route path="/" />
+        <Route index element={<HomePageComponents />} />
+        <Route path="NutritionalInformation">
+          <Route index element={<NutritionalInformation showFood />} />
 
-        <Route path="Nutrition">
-          <Route index element={<NutritionalInformation showFood={false}/>}/>
-          <Route path=":nutritionName" element={<NutritionDetailsComponent />}/>
-        </Route>
+          <Route path="Nutrition">
+            <Route index element={<NutritionalInformation showFood />} />
+            <Route path=":nutritionName" element={<NutritionDetailsComponent />} />
+          </Route>
 
-        <Route path=":foodCategory">
-          <Route index element={<FoodCategory />} />
-          <Route path=":foodName" element={<FoodDetailsComponent />} />
-        </Route>
-
-        <Route path="FruitAndVegetables">
-          <Route index element={<FoodCategory />} />
           <Route path=":foodCategory">
             <Route index element={<FoodCategory />} />
             <Route path=":foodName" element={<FoodDetailsComponent />} />
           </Route>
+
+          <Route path="FruitAndVegetables">
+            <Route index element={<FoodCategory />} />
+            <Route path=":foodCategory">
+              <Route index element={<FoodCategory />} />
+              <Route path=":foodName" element={<FoodDetailsComponent />} />
+            </Route>
+          </Route>
         </Route>
-      </Route>
-      <Route path="FitnessChallenges">
-        <Route index element={<Challenges />} />
-        <Route path=":challengeName" element={<ChallengeDetailsComponent />} />
-      </Route>
-      <Route path="Videos">
-        <Route index element={<VideosComponent />} />
-      </Route>
+        <Route path="FitnessChallenges">
+          <Route index element={<Challenges />} />
+          <Route path=":challengeName" element={<ChallengeDetailsComponent />} />
+        </Route>
+        <Route path="Videos">
+          <Route index element={<VideosComponent />} />
+        </Route>
         <Route path="Recipes">
           <Route index element={<Recipes />} />
         </Route>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -26,7 +26,7 @@ const App: React.FC = () => (
       <Routes>
         <Route path="/" />
         <Route index element={<HomePageComponents />} />
-        <Route path="NutritionalInformation">
+        <Route path="FoodAndNutrition">
           <Route index element={<NutritionalInformation showFood />} />
 
           <Route path="Nutrition">

--- a/src/components/app_header/Navbar/Navbar.tsx
+++ b/src/components/app_header/Navbar/Navbar.tsx
@@ -32,7 +32,7 @@ const Navbar = () => {
               </div>
               <div className="flex justify-end xl:justify-center w-full">
                 <div className="hidden xl:flex justify-evenly w-7/12 font-navigation-items font-bold text-titansDarkBlue text-[16px] hover:text-gray-900">
-                  <Link to="/NutritionalInformation">Food & Nutrition</Link>
+                  <Link to="/FoodAndNutrition">Food & Nutrition</Link>
                   <Link to="/FitnessChallenges">Fitness Challenges</Link>
                   <Link to="/Games">Games</Link>
                   <Link to="/Videos">Videos</Link>
@@ -79,7 +79,7 @@ const Navbar = () => {
                 <a href="/">Home</a>
               </li>
               <li className="border-gray-400 my-2  text-sm font-medium text-bold text-titansDarkBlue hover:text-gray-900">
-                <a href="/NutritionalInformation">Food & Nutrition</a>
+                <a href="/FoodAndNutrition">Food & Nutrition</a>
               </li>
               <li className="border-gray-400 my-2 text-sm font-medium text-titansDarkBlue hover:text-gray-900">
                 <a href="/FitnessChallenges">Fitness Challenges</a>

--- a/src/components/breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.test.tsx
@@ -18,7 +18,7 @@ describe("Breadcrumb Component", () => {
   });
 
   it("should have correct text as determined by the route", () => {
-    const route = "/NutritionalInformation";
+    const route = "/FoodAndNutrition";
     const { getByText } = render(
       <RoutingTestWrapper path={route}>
         <Route path={route} element={<Breadcrumbs styling="" />} />
@@ -29,7 +29,7 @@ describe("Breadcrumb Component", () => {
   });
 
   it("should render multiple breadcrumbs as determined by the route", () => {
-    const route = "/NutritionalInformation/Test";
+    const route = "/FoodAndNutrition/Test";
     render(
       <MemoryRouter initialEntries={["/", route]}>
         <Routes>

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -9,8 +9,8 @@ interface BreadcrumbsProps {
 const Breadcrumbs = (props: BreadcrumbsProps) => {
   const routes = [
     { path: "/", breadcrumb: null },
-    { path: "NutritionalInformation", breadcrumb: "Food & Nutrition" },
-    { path: "NutritionalInformation/Nutrition", breadcrumb: null },
+    { path: "FoodAndNutrition", breadcrumb: "Food & Nutrition" },
+    { path: "FoodAndNutrition/Nutrition", breadcrumb: null },
   ];
 
   const breadcrumbs = useBreadcrumbs(routes);

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -9,7 +9,6 @@ interface BreadcrumbsProps {
 const Breadcrumbs = (props: BreadcrumbsProps) => {
   const routes = [
     { path: "/", breadcrumb: null },
-    { path: "FoodAndNutrition", breadcrumb: "Food & Nutrition" },
     { path: "FoodAndNutrition/Nutrition", breadcrumb: null },
   ];
 

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -10,6 +10,7 @@ const Breadcrumbs = (props: BreadcrumbsProps) => {
   const routes = [
     { path: "/", breadcrumb: null },
     { path: "NutritionalInformation", breadcrumb: "Food & Nutrition" },
+    { path: "NutritionalInformation/Nutrition", breadcrumb: null },
   ];
 
   const breadcrumbs = useBreadcrumbs(routes);

--- a/src/components/nutritional_Information/food/FoodCategory.test.tsx
+++ b/src/components/nutritional_Information/food/FoodCategory.test.tsx
@@ -8,7 +8,7 @@ import FoodCategoryData from "../../../data/nutritional_information/FoodCategory
 
 describe("Food Category Component", () => {
   test("renders with no category", async () => {
-    const route = "/NutritionalInformation";
+    const route = "/FoodAndNutrition";
 
     const { asFragment } = render(
       <RoutingTestWrapper path={route}>
@@ -24,7 +24,7 @@ describe("Food Category Component", () => {
 
   test("renders with category", () => {
     const category = FoodCategoryData[0];
-    const route = `/NutritionalInformation/${category.name}`;
+    const route = `/FoodAndNutrition/${category.name}`;
 
     render(
       <RoutingTestWrapper path={route}>
@@ -36,7 +36,7 @@ describe("Food Category Component", () => {
   });
 
   test("fallsback if no category is found", () => {
-    const route = "/NutritionalInformation/NotARealCategory";
+    const route = "/FoodAndNutrition/NotARealCategory";
 
     render(
       <RoutingTestWrapper path={route}>
@@ -45,13 +45,13 @@ describe("Food Category Component", () => {
     );
 
     waitFor(() => {
-      expect(window.location.pathname).toBe("/NutritionalInformation");
+      expect(window.location.pathname).toBe("/FoodAndNutrition");
     });
   });
 
   test("renders with no category & can click on a card", async () => {
     const category = FoodCategoryData[0];
-    const route = "/NutritionalInformation";
+    const route = "/FoodAndNutrition";
     const user = userEvent.setup();
 
     render(
@@ -66,7 +66,7 @@ describe("Food Category Component", () => {
 
     waitFor(() => {
       expect(screen.findByTestId("menutitle-title")).toHaveTextContent(category.name);
-      expect(window.location.pathname).toBe(`/NutritionalInformation/${category.name}`);
+      expect(window.location.pathname).toBe(`/FoodAndNutrition/${category.name}`);
     });
   });
 });

--- a/src/components/nutritional_Information/food/FoodCategory.tsx
+++ b/src/components/nutritional_Information/food/FoodCategory.tsx
@@ -26,7 +26,7 @@ const FoodCategory = () => {
       setCategoryTitle(category);
     } else {
       // if the category is not found then redirect to the nutritional information page
-      navigate("/NutritionalInformation");
+      navigate("/FoodAndNutrition");
     }
   }, []);
 

--- a/src/components/nutritional_Information/food_details/FoodDetailsComponent.test.tsx
+++ b/src/components/nutritional_Information/food_details/FoodDetailsComponent.test.tsx
@@ -67,12 +67,12 @@ describe("Food Details Component", () => {
     // Using memoryrouter to mock Route as path to the component is required for the contents
     const { asFragment } = render(
       <MemoryRouter
-        initialEntries={[{ pathname: "/NutritionalInformation/mockCategory/mock3" }]}
+        initialEntries={[{ pathname: "/FoodAndNutrition/mockCategory/mock3" }]}
         initialIndex={0}
       >
         <Routes>
           <Route
-            path="/NutritionalInformation/mockCategory/:foodName"
+            path="/FoodAndNutrition/mockCategory/:foodName"
             element={<FoodDetailsComponent />}
           />
         </Routes>

--- a/src/components/nutritional_Information/food_details/FoodDetailsComponent.tsx
+++ b/src/components/nutritional_Information/food_details/FoodDetailsComponent.tsx
@@ -12,7 +12,7 @@ import useWindowDimensions from "../../../functions/ScreenWidth";
 import { useGlobalMenuOpenContext } from "../../app_header/AppHeaderContext";
 
 const FoodDetailsComponent = () => {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const [getFoodDetailsComponentData, setFoodDetailsComponentData] = useState<
     FoodDetailsProps | undefined
   >();
@@ -20,7 +20,7 @@ const FoodDetailsComponent = () => {
   const { width } = useWindowDimensions();
   const [getImageURL, setImageURL] = useState<string>();
   const [getSeeNext, setSeeNext] = useState<MenuCardProps[] | undefined>();
-  const { foodName , foodCategory } = useParams();
+  const { foodName, foodCategory } = useParams();
   const location = useLocation();
 
   const fetchSeeNext = async (res: FoodDetailsProps) => {
@@ -54,9 +54,8 @@ const FoodDetailsComponent = () => {
             FirebaseAPI.fetchImages(res.firebaseName).then((URI) => setImageURL(URI));
             setFoodDetailsComponentData(res);
           }
-        }
-        else{
-          navigate(`/NutritionalInformation/${foodCategory}`)
+        } else {
+          navigate(`/FoodAndNutrition/${foodCategory}`);
         }
       });
     }

--- a/src/components/nutritional_Information/food_details/__snapshots__/FoodDetailsComponent.test.tsx.snap
+++ b/src/components/nutritional_Information/food_details/__snapshots__/FoodDetailsComponent.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Food Details Component component renders both correct data and image fr
           class="active"
           href="/FoodAndNutrition"
         >
-           Food &  Nutrition
+           Food & Nutrition
         </a>
         <p
           class="text text-titansBrightPink"

--- a/src/components/nutritional_Information/food_details/__snapshots__/FoodDetailsComponent.test.tsx.snap
+++ b/src/components/nutritional_Information/food_details/__snapshots__/FoodDetailsComponent.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Food Details Component component renders both correct data and image fr
         <a
           aria-current="page"
           class="active"
-          href="/NutritionalInformation"
+          href="/FoodAndNutrition"
         >
            Food &  Nutrition
         </a>
@@ -27,7 +27,7 @@ exports[`Food Details Component component renders both correct data and image fr
         <a
           aria-current="page"
           class="active"
-          href="/NutritionalInformation/mockCategory"
+          href="/FoodAndNutrition/mockCategory"
         >
            Mock Category
         </a>
@@ -39,7 +39,7 @@ exports[`Food Details Component component renders both correct data and image fr
         <a
           aria-current="page"
           class="active"
-          href="/NutritionalInformation/mockCategory/mock3"
+          href="/FoodAndNutrition/mockCategory/mock3"
         >
            Mock3
         </a>

--- a/src/components/nutritional_Information/nutritional/NutritionCategory.tsx
+++ b/src/components/nutritional_Information/nutritional/NutritionCategory.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams, useLocation } from "react-router";
+import { useParams } from "react-router";
 import { MenuCardProps } from "../../../models/MenuCardProps";
 import NutritionCategoryData from "../../../data/nutritional_information/NutritionCategoryData";
 import {
@@ -14,17 +14,9 @@ import Menu from "../../shared/Menu";
 
 const NutritionCategory = () => {
   const { nutritionCategory } = useParams();
-  const loc = useLocation()
 
   function getNutritionData() {
-    let data = [...NutritionCategoryData]
-    if(loc.pathname.endsWith("Nutrition") || loc.pathname.endsWith("Nutrition/")){
-      data = data.map(element => {
-        const newElement = {...element}
-        newElement.path = newElement.path.replace("Nutrition/","")
-        return newElement
-      })
-    }
+    const data = [...NutritionCategoryData];
     switch (nutritionCategory) {
       case "Fat":
         return FatTextData;
@@ -46,15 +38,15 @@ const NutritionCategory = () => {
   const nutritionData: MenuCardProps[] = getNutritionData();
 
   return (
-      <div>
-        <Menu
-          title={{
-            title: "Explore nutrition",
-            subtitle: "Click on the type of nutritional information you want to learn about",
-          }}
-          cards={nutritionData}
-        />
-      </div>
+    <div>
+      <Menu
+        title={{
+          title: "Explore nutrition",
+          subtitle: "Click on the type of nutritional information you want to learn about",
+        }}
+        cards={nutritionData}
+      />
+    </div>
   );
 };
 

--- a/src/data/HomePageComponentsData.ts
+++ b/src/data/HomePageComponentsData.ts
@@ -4,7 +4,7 @@ const HomePageComponentsData: MenuCardProps[] = [
   {
     key: 0,
     name: "Food & Nutrition",
-    path: "/NutritionalInformation",
+    path: "/FoodAndNutrition",
     firebaseName: "HomePageImages/apple.svg",
   },
   {


### PR DESCRIPTION
- renamed NutritionalInformation to FoodAndNutrition where applicable
- fixed breadcrumb showing 'Nutrition' Route
- Navigating to 'FoodAndNutrition/Nutrition' now takes you back to 'FoodAndNutrition' Page
- removed some code that now seems redundant in 'nutritionCategory' (please correct me if I'm mistaken)